### PR TITLE
Image service after hook - post painting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -480,7 +480,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.16.2.tgz",
       "integrity": "sha1-uk+S8XFn37q0CYN4VFS5rBScPG0=",
       "requires": {
-        "follow-redirects": "1.2.4",
+        "follow-redirects": "1.2.5",
         "is-buffer": "1.1.5"
       }
     },
@@ -3954,9 +3954,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.2.4.tgz",
-      "integrity": "sha512-Suw6KewLV2hReSyEOeql+UUkBVyiBm3ok1VPrVFRZnQInWpdoZbbiG5i8aJVSjTr0yQ4Ava0Sh6/joCg1Brdqw==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.2.5.tgz",
+      "integrity": "sha512-lMhwQTryFbG+wYsAIEKC1Kf5IGDlVNnONRogIBllh7LLoV7pNIxW0z9fhjRar9NBql+hd2Y49KboVVNxf6GEfg==",
       "requires": {
         "debug": "2.6.9"
       }

--- a/src/models/paintings.model.js
+++ b/src/models/paintings.model.js
@@ -9,6 +9,18 @@ module.exports = function (app) {
     url: {
       type: DataTypes.STRING,
       allowNull: false
+    },
+    position: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      defaultValue: 0
+    },
+    userId: {
+      type: DataTypes.INTEGER,
+      references: {
+        model: 'users',
+        key: 'id'
+      }
     }
   }, {
     hooks: {

--- a/src/services/paintings/paintings.service.js
+++ b/src/services/paintings/paintings.service.js
@@ -12,7 +12,7 @@ module.exports = function () {
   const options = {
     name: 'paintings',
     Model,
-    paginate
+    // paginate
   };
 
   // Initialize our service with any options it requires


### PR DESCRIPTION
User story: As a user, I can upload an image to the database, see it later, ensure that it belongs to me, and do all the aforementioned quickly.

Implementation: Wrote an after hook for the `s3/images/new` service so that it posts a new painting after a successful upload.